### PR TITLE
Added support for PI2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,12 @@
 obj-m += rfm12b.o
 
 KVERSION := $(shell uname -r)
+UAPI = /lib/modules/$(KVERSION)/build/include/generated/uapi
 
 # 3.7 moved version.h to a different location
-#if [ -f /lib/modules/$(KVERSION)/build/include/generated/uapi/linux/version.h ]; then \
-#INCLUDE += -I/lib/modules/$(KVERSION)/build/include/generated/uapi/
+ifeq ($wildcard $(UAPI)/linux/version.h),)
+INCLUDE += -I/lib/modules/$(KVERSION)/build/include/generated/uapi/
+endif
 
 all:
 	make -C /lib/modules/$(KVERSION)/build $(INCLUDE) M=$(PWD) modules

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,8 @@ obj-m += rfm12b.o
 KVERSION := $(shell uname -r)
 
 # 3.7 moved version.h to a different location
-if [ -f /lib/modules/$(KVERSION)/build/include/generated/uapi/linux/version.h ]; then \
-	INCLUDE += -I/lib/modules/$(KVERSION)/build/include/generated/uapi/
+#if [ -f /lib/modules/$(KVERSION)/build/include/generated/uapi/linux/version.h ]; then \
+#INCLUDE += -I/lib/modules/$(KVERSION)/build/include/generated/uapi/
 
 all:
 	make -C /lib/modules/$(KVERSION)/build $(INCLUDE) M=$(PWD) modules

--- a/examples/rfm12b_ook/rfm12b_ook.py
+++ b/examples/rfm12b_ook/rfm12b_ook.py
@@ -1,0 +1,110 @@
+import fcntl
+import array
+import struct
+import ioctl_opt
+import ctypes
+import time
+
+DEVNAME = '/dev/rfm12b.0.1'
+RFM12B_SPI_MAJOR = ord('r')
+RFM12B_OOK_CMD_MAX_LEN = 200
+
+
+class rfm12b_stats(ctypes.Structure):
+    _fields_ = [
+        ('bytes_recvd', ctypes.c_ulong),
+        ('bytes_sent', ctypes.c_ulong),
+        ('pkts_recvd', ctypes.c_ulong),
+        ('pkts_sent', ctypes.c_ulong),
+        ('num_recv_overflows', ctypes.c_ulong),
+        ('num_recv_timeouts', ctypes.c_ulong),
+        ('num_recv_crc16_fail', ctypes.c_ulong),
+        ('num_send_underruns', ctypes.c_ulong),
+        ('num_send_timeouts', ctypes.c_ulong),
+        ('low_battery', ctypes.c_ulong),
+    ]
+
+    @classmethod
+    def get_ioctl_request(cls):
+        return ioctl_opt.IOR(
+            RFM12B_SPI_MAJOR, 0, ctypes.POINTER(cls))
+
+
+class rfm12b_ook_cmds(ctypes.Structure):
+    _fields_ = [
+        ('len', ctypes.c_int),
+        ('delay_us', ctypes.c_uint),
+        ('cmds', ctypes.c_ubyte * RFM12B_OOK_CMD_MAX_LEN),
+    ]
+
+    @classmethod
+    def get_ioctl_request(cls):
+        return ioctl_opt.IOW(
+            RFM12B_SPI_MAJOR, 11, ctypes.POINTER(cls))
+
+
+class switch(object):
+    SYNC = 'S'
+    FLOAT = 'F'
+    ONE = '1'
+    ZERO = '0'
+
+    SW_CMD_ON = 1
+    SW_CMD_OFF = 2
+
+    DELAY_CLK = 375
+    REPEAT_COUNT = 3
+
+    code = {
+        ZERO: [0b10001000],
+        ONE: [0b11101110],
+        FLOAT: [0b10001110],
+        SYNC: [0b10000000, 0, 0, 0],
+        }
+
+    def __init__(self, system, unit, repeat=1):
+        self.system = system
+        self.unit = unit
+        self.repeat = repeat
+        self.rf12 = None
+
+    def __enter__(self):
+        self.rf12 = open(DEVNAME, 'wb')
+        return self
+
+    def __exit__(self, type_, value, traceback):
+        self.rf12.close()
+
+    def _do_cmd(self, cmd):
+        frame = (self.system + self.unit + cmd + self.SYNC) * self.repeat
+        print len(frame), repr(frame)
+
+        ook = rfm12b_ook_cmds()
+        ook.delay_us = 200
+        k = 0
+        for bit in frame:
+            for encd in self.code[bit]:
+                ook.cmds[k] = encd
+                k += 1
+        ook.len = k
+
+        return fcntl.ioctl(self.rf12, ook.get_ioctl_request(), ook)
+
+    def on(self):
+        self._do_cmd(self.FLOAT + self.ZERO)
+
+    def off(self):
+        self._do_cmd(self.ZERO + self.FLOAT)
+
+
+def main():
+    with switch('0FFFF', '0FFFF', repeat=4) as unita:
+        while True:
+            unita.on()
+            time.sleep(1)
+            unita.off()
+            time.sleep(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/platform/plat_raspberrypi.h
+++ b/platform/plat_raspberrypi.h
@@ -37,9 +37,13 @@
 // as well.
 #define NUM_RFM12_BOARDS         1
 
+
+
 #ifdef PI2
+//BCM2708_PERI_BASE = 0x3f000000
 #define GPIO_BASE 0x3f200000
 #else
+//BCM2708_PERI_BASE = 0x20000000
 #define GPIO_BASE 0x20200000
 #endif
 

--- a/platform/plat_raspberrypi.h
+++ b/platform/plat_raspberrypi.h
@@ -37,6 +37,12 @@
 // as well.
 #define NUM_RFM12_BOARDS         1
 
+#ifdef PI2
+#define GPIO_BASE 0x3f200000
+#else
+#define GPIO_BASE 0x20200000
+#endif
+
 /*
 *  default config for raspberry pi (one RFM12 module)
 *
@@ -73,12 +79,12 @@ static int
 spi_rfm12_init_pinmux_settings(void)
 {
 // taken from https://github.com/bootc/linux/blob/rpi-i2cspi/drivers/spi/spi-bcm2708.c
-   
+
 #define INP_GPIO(g) *(gpio+((g)/10)) &= ~(7<<(((g)%10)*3))
 #define SET_GPIO_ALT(g,a) *(gpio+(((g)/10))) |= (((a)<=3?(a)+4:(a)==4?3:2)<<(((g)%10)*3))
 
    int pin;
-   u32* gpio = ioremap(0x20200000, SZ_16K);
+   u32* gpio = ioremap(GPIO_BASE, SZ_16K);
    
    // SPI0 is on gpio 7..11
    for (pin = 7; pin <= 11; pin++) {

--- a/rfm12b.c
+++ b/rfm12b.c
@@ -1236,7 +1236,7 @@ static void
 rfm12_ook_completion(void *context)
 {
   struct spi_message *spi_msg = context;
-  dev_info(spi_msg->spi, "ook: transfer completed. status = %d", spi_msg->status);
+  dev_info(&spi_msg->spi->dev, "ook: transfer completed. status = %d", spi_msg->status);
 }
 
 #define RFM12_LOW_POWER_MODE 0x9807

--- a/rfm12b_config.h
+++ b/rfm12b_config.h
@@ -60,7 +60,7 @@
   Each RFM12B needs to have the same group ID to talk to each other.
   Change this to whatever you want, (needs to be between 0 and 255).
 */
-#define RFM12B_DEFAULT_GROUP_ID   211
+#define RFM12B_DEFAULT_GROUP_ID   0
 
 /*
   The default frequency band to use for each RFM12B board. You can change
@@ -74,7 +74,7 @@
      1 ... 433mhz
      2 ... 868mhz
 */
-#define RFM12B_DEFAULT_BAND_ID   2
+#define RFM12B_DEFAULT_BAND_ID   1
 
 /*
   The default bit rate to use for each RFM12B board. You can change the

--- a/rfm12b_config.h
+++ b/rfm12b_config.h
@@ -34,8 +34,11 @@
   Raspberry Pi      1               platform/plat_raspberrypi.h
   Beaglebone        2               platform/plat_beaglebone.h
   Beaglebone Black  3               platform/plat_beaglebone.h
+
 */
-#define RFM12B_BOARD        0
+#define RFM12B_BOARD        1
+// Uncomment for PI B2 board
+#define PI2
 
 /*
   The name of the driver within the kernel (e.g. shows up in logs, etc...)

--- a/rfm12b_ioctl.h
+++ b/rfm12b_ioctl.h
@@ -115,6 +115,9 @@
 */
 #define RFM12B_IOCTL_SET_JEEMODE_AUTOACK  _IOW(RFM12B_SPI_MAJOR, 10, int)
 
+#define RFM12B_IOCTL_SEND_OOK _IOW(RFM12B_SPI_MAJOR, 11, rfm12_ook_cmds*)
+
+
 /*
    Structure for driver statistics (see RFM12B_IOCTL_GET_STATS).
    
@@ -135,5 +138,14 @@ typedef struct
       num_send_timeouts,   // timeout count during sending
       low_battery;         // yes/no if rfm12b Vcc is currently below threshold
 } rfm12b_stats;
+
+#define RFM12B_OOK_CMD_MAX_LEN 200
+
+typedef struct
+{
+  int len;
+  unsigned int delay_us;
+  unsigned char cmds[RFM12B_OOK_CMD_MAX_LEN];
+} rfm12_ook_cmds;
 
 #endif // __RFM12B_IOCTL_H__


### PR DESCRIPTION
I've changed the hard coded ioremap to GPIO_BASE but the kernel headers for the Pi appear to be missing the correct values. In the mean time I've added those values into the plat_raspberrypi header. 

This gets the RFM12B hardware working on Pi B2